### PR TITLE
Update documentation to use recommended fastapi startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pre-commit install
 ## Running the Server
 
 ```bash
-uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+fastapi dev app/main.py
 ```
 
 Then visit:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -46,7 +46,7 @@ def login(
             headers={"WWW-Authenticate": "Bearer"},
         )
     access_token = auth_service.create_access_token({"sub": user["username"]})
-    return Token(access_token=access_token, token_type="bearer")  # ruff: noqa S106
+    return Token(access_token=access_token, token_type="bearer")
 
 
 @router.get("/me", response_model=User)

--- a/backend/scripts/setup_ml_data.py
+++ b/backend/scripts/setup_ml_data.py
@@ -87,7 +87,7 @@ def main():
         logger.info("Setup completed successfully!")
         logger.info("The recommendation system is now ready to use.")
         logger.info("You can start the backend server with:")
-        logger.info("  uvicorn app.main:app --reload")
+        logger.info("  fastapi dev app/main.py")
 
     except FileNotFoundError:
         logger.exception("Required file missing: %s")


### PR DESCRIPTION
Switched from the uvicorn reload command to the standard fastapi startup