### PR TITLE
Fixed regex title search

### DIFF
--- a/frontend/hooks/tmdb/useTMDB.ts
+++ b/frontend/hooks/tmdb/useTMDB.ts
@@ -38,7 +38,7 @@ export function useTMDB(title: string, tmdbId?: number | string) {
         }
 
         // If ID not available try searching by move name (Secondary option needed for popularity ranking nowd)
-        const cleanTitle = title.replace(/ \(\d{4}\)$/, '').trim();
+        const cleanTitle = title.replace(/ \((?:a\.?k\.?a\.? .*?|\d{4})\)/gi, '').trim();
         
         if (cleanTitle) {
             const searchRes = await fetch(


### PR DESCRIPTION
Quick fix

Movies that relied on title search to get their posters were not identified by previous regex pattern

Updated the pattern to include movies with alternate title formats like "Twelve Monkies (a.k.a...) (Date)"