### PR TITLE
quick fix for tie-breaking scenario

### DIFF
--- a/frontend/src/app/game/page.tsx
+++ b/frontend/src/app/game/page.tsx
@@ -101,8 +101,13 @@ export default function GamePage() {
 
   const handleRatingGuess = (selectedId: number) => {
     if (!movieA || !movieB) return;
-    const winnerId = movieA.average_rating >= movieB.average_rating ? movieA.movie_id : movieB.movie_id;
-    if (selectedId === winnerId) setScore(s => s + 1);
+    
+    const selectedMovie = selectedId === movieA.movie_id ? movieA : movieB;
+    const otherMovie = selectedId === movieA.movie_id ? movieB : movieA;
+    if (selectedMovie.average_rating >= otherMovie.average_rating) {
+      setScore(s => s + 1);
+    }
+    
     setGameState("rating_reveal");
   };
 


### PR DESCRIPTION
Hey guys, welcome back to today's PR. On this episode, I realized that in our demo video I said my code did one thing, while it really did another. Thankfully, I was able to catch this bug and update the logic so that when the game results in a tie, you actually get points no matter what movie you pick. Hope you enjoy, and don't forget to like and subscribe! see you in the next one, later!